### PR TITLE
Fixes unwanted throw in `hasAllAttributes`

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -231,7 +231,7 @@ function hasAllAttributes( obj, attributes, not ) {
 		attributeValue = attributes[attribute];
 
 		if ( !obj.hasOwnProperty( attribute ) ) {
-			throw new Error( 'The attribute ' + attribute + ' does not exist on a ' + typeof ( obj ) );
+			return false;
 		}
 
 		var isSame = compare( attributeValue, obj[attribute] );


### PR DESCRIPTION
While using `aeq(SelectorString)` it threw an error if the object didn't have the prop I was filtering (`guideLayer=true` which isn't present on Camera Layers for instance). So it broke the selector instead of silently ignoring it.