### PR TITLE
dom: turn off separate properties by default

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -235,7 +235,7 @@ aeq.extend({
 	getProperties: function ( layers, options ) {
 		aeq.assertIsNotNull( layers, 'layer is null' );
 
-		options = setDefault( options, { separate: true });
+		options = setDefault( options, { separate: false });
 
 		var arr = [];
 


### PR DESCRIPTION
re issue #65

it's counterintuitive that a function to get properties also does something else, which in turn causes animation data to be lost.

Is backward compatibility an issue? I suppose not many have scripts that rely on this behaviour