### PR TITLE
Update docs url link to docsforadobe

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ if (comp) {
 
 Documentation
 -------------
-[For documentation, visit aenhancers.github.io/aequery](https://aenhancers.github.io/aequery/)
+[For documentation, visit docsforadobe.github.io/aequery](https://docsforadobe.github.io/aequery/)
 
 
 Development


### PR DESCRIPTION
Fixes #70 

## Changes 
- Update documentation link and link text from `aenhancers` to `docsforadobe`